### PR TITLE
option: metadata

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,35 @@
-function tags2dlx() {
-  return {
-    title:      {},
-    utterances: [],
-  };
+/**
+ * Default options for the tags2dlx function
+ * @type {Object}
+ */
+const defaultOptions = {
+  metadata: {},
+};
+
+/**
+ * Default (empty) DLx Text object
+ * @type {Object}
+ */
+const defaultText = {
+  title:      {},
+  utterances: [],
+};
+
+/**
+ * Convert a tagged text to DLx JSON format
+ * @param  {String} [text=``]                The tagged text to convert
+ * @param  {Object} [options=defaultOptions] An options object
+ * @param  {Object} [options.metadata={}]    An object containing additional metadata to add to the text, such as title, etc.
+ * @return {Object}                          Returns a DLx Text object
+ */
+function tags2dlx(text = ``, { metadata } = defaultOptions) {
+
+  const json = { ...defaultText, ...Object(metadata) };
+
+  json.utterances = [];
+
+  return json;
+
 }
 
 export default tags2dlx;

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -2,4 +2,5 @@ env:
   jasmine: true
 rules:
   func-names: off
+  max-nested-callbacks: off
   prefer-arrow-callback: off

--- a/test/test.js
+++ b/test/test.js
@@ -11,12 +11,57 @@ describe(`tags2dlx`, function() {
     text = await readFile(path.join(__dirname, `./test.txt`), `utf8`);
   });
 
-  it(`returns a valid DLx Text object`, function() {
+  describe(`options`, function() {
 
-    const output = convert(text);
+    describe(`metadata`, function() {
 
-    expect(typeof output.title).toBe(`object`);
-    expect(Array.isArray(output.utterances)).toBe(true);
+      it(`copies metadata to the Text`, function() {
+
+        const hello = `world`;
+        const title = `How the world began`;
+
+        const options = {
+          metadata: {
+            hello,
+            title,
+          },
+        };
+
+        const output = convert(text, options);
+
+        expect(output.hello).toBe(hello);
+        expect(output.title).toBe(title);
+
+      });
+
+      it(`does not overwrite the utterances property`, function() {
+
+        const options = {
+          metadata: {
+            utterances: [{}, {}, {}],
+          },
+        };
+
+        const output = convert(text, options);
+
+        expect(output.utterances.length).toBe(0);
+
+      });
+
+    });
+
+  });
+
+  describe(`result`, function() {
+
+    it(`is a valid DLx Text object`, function() {
+
+      const output = convert(text);
+
+      expect(typeof output.title).toBe(`object`);
+      expect(Array.isArray(output.utterances)).toBe(true);
+
+    });
 
   });
 


### PR DESCRIPTION
This PR adds a `metadata` option to the `tags2dlx` function which allows the user to add metadata to the resulting Text object, like `title`, `speaker`, etc.