### PR TITLE
NEW: tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For example, here is an example sentence from the [Open American National Corpus
 All_DT hotels_NNS accept_VBP major_JJ credit_NN cards_NNS ._.
 ```
 
-Each word in this sentence has been tagged for part of speech by adding an underscore at the end of the word, followed by an abbreviation indicating the part of speech. For example, the word _hotels_ has been tagged as a plural noun using the abbreviation `NNS`.
+Each word in this sentence has been tagged for part of speech by adding an underscore at the end of the word, followed by an abbreviation indicating the part of speech. For example, the word _hotels_ has been tagged as a plural noun using the abbreviation `NNS`. Punctuation is typically tagged as well (`._.` in the above example).
 
 Using this library, you can convert tagged texts like this to JSON format, like so:
 
@@ -61,7 +61,7 @@ Usage in Node.js (latest stable release):
 ```js
 import convert from '@digitallinguistics/tags2dlx';
 
-const text = `This_DEM is_V a_DET sentence_N.`;
+const text = `This_DEM is_V a_DET sentence_N ._.`;
 
 // The output is a plain-old JavaScript object (POJO), formatted as a DLx Text object
 const output = convert(text);

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,4 @@
-/**
- * Default options for the tags2dlx function
- * @type {Object}
- */
-const defaultOptions = {
-  metadata: {},
-};
+// CONSTANTS
 
 /**
  * Default (empty) DLx Text object
@@ -16,20 +10,86 @@ const defaultText = {
 };
 
 /**
- * Convert a tagged text to DLx JSON format
- * @param  {String} [text=``]                The tagged text to convert
- * @param  {Object} [options=defaultOptions] An options object
- * @param  {Object} [options.metadata={}]    An object containing additional metadata to add to the text, such as title, etc.
- * @return {Object}                          Returns a DLx Text object
+ * Regular expression for finding one or more white spaces
+ * @type {RegExp}
  */
-function tags2dlx(text = ``, { metadata } = defaultOptions) {
+const whiteSpaceRegExp = /\s+/gu;
+
+
+// METHODS
+
+/**
+ * Creates a function to parse a tagged word into the word token and its tag.
+ * @param  {String}   tagSeparator The tag separator to split on (sits between the word token and its tag)
+ * @return {Function}              Returns the parseTaggedWord function
+ */
+function createWordParser(tagSeparator) {
+  /**
+   * Parses a tagged word into the word token and its tag
+   * @param  {String} taggedWord The tagged word to parse
+   * @return {Object}            Returns an object with "tag" and "token" properties
+   */
+  return taggedWord => {
+    const [token, tag] = taggedWord.split(tagSeparator);
+    return { tag, token };
+  };
+}
+
+// MAIN
+
+/**
+ * Convert a tagged text to DLx JSON format
+ * @param  {String} [text=``]                             The tagged text to convert
+ * @param  {Object} [options]                             An options object
+ * @param  {Object} [options.metadata={}]                 An object containing additional metadata to add to the Text, such as title, etc.
+ * @param  {String} [options.punctuation=`,`]             Punctuation to ignore. Tagged items consisting of one of these characters will be removed from the output.
+ * @param  {String} [options.tagSeparator=`_`]            The character(s) delimiting the word token from its tag
+ * @param  {String} [options.utteranceSeparators=`.!?"'`] A string containing all the characters to treat as utterance separators.
+ * @return {Object}                                       Returns a DLx Text object
+ */
+export default function tags2dlx(
+  text = ``,
+  {
+    metadata            = {},
+    punctuation         = `,`,
+    tagSeparator        = `_`,
+    utteranceSeparators = `.!?"'`,
+  } = {},
+) {
+
+  punctuation         = [...punctuation];         // eslint-disable-line no-param-reassign
+  utteranceSeparators = [...utteranceSeparators]; // eslint-disable-line no-param-reassign
+
+  const parseTaggedWord = createWordParser(tagSeparator);
+
+  const taggedWords = text.split(whiteSpaceRegExp);
+  const parsedWords = taggedWords.map(parseTaggedWord);
+
+  const rawUtterances = parsedWords.reduce((arr, word) => {
+
+    if (punctuation.includes(word.token)) return arr;
+
+    if (utteranceSeparators.includes(word.token)) {
+
+      arr.push({ words: [] });
+
+    } else {
+
+      const lastUtterance = arr[arr.length - 1];
+      lastUtterance.words.push(word);
+
+    }
+
+    return arr;
+
+  }, [{ words: [] }]);
+
+  const nonEmptyUtterances = rawUtterances.filter(u => u.words.length);
 
   const json = { ...defaultText, ...Object(metadata) };
 
-  json.utterances = [];
+  json.utterances = nonEmptyUtterances;
 
   return json;
 
 }
-
-export default tags2dlx;

--- a/src/index.js
+++ b/src/index.js
@@ -66,8 +66,10 @@ export default function tags2dlx(
   .split(whiteSpaceRegExp)
   .map(parseTaggedWord);
 
+  // NB: To keep this code readable, don't chain this off the words array
   const utterances = words.reduce((arr, word) => {
 
+    // if current word token is an utterance separator, start a new utterance
     if (utteranceSeparators.includes(word.token)) {
 
       arr.push({ words: [] });
@@ -78,6 +80,7 @@ export default function tags2dlx(
 
       return arr;
 
+    // add current word token to current utterance
     } else {
 
       const lastUtterance = arr[arr.length - 1];

--- a/src/index.js
+++ b/src/index.js
@@ -62,16 +62,21 @@ export default function tags2dlx(
 
   const parseTaggedWord = createWordParser(tagSeparator);
 
-  const taggedWords = text.split(whiteSpaceRegExp);
-  const parsedWords = taggedWords.map(parseTaggedWord);
+  const words = text
+  .split(whiteSpaceRegExp)
+  .map(parseTaggedWord);
 
-  const rawUtterances = parsedWords.reduce((arr, word) => {
-
-    if (punctuation.includes(word.token)) return arr;
+  const utterances = words.reduce((arr, word) => {
 
     if (utteranceSeparators.includes(word.token)) {
 
       arr.push({ words: [] });
+
+    // filter out punctuation words *after* tokenizing text into utterances
+    // in case the same character is included in both punctuation and utterance separators
+    } else if (punctuation.includes(word.token)) {
+
+      return arr;
 
     } else {
 
@@ -82,14 +87,13 @@ export default function tags2dlx(
 
     return arr;
 
-  }, [{ words: [] }]);
+  }, [{ words: [] }])
+  .filter(u => u.words.length);
 
-  const nonEmptyUtterances = rawUtterances.filter(u => u.words.length);
-
-  const json = { ...defaultText, ...Object(metadata) };
-
-  json.utterances = nonEmptyUtterances;
-
-  return json;
+  return {
+    ...defaultText,
+    ...Object(metadata),
+    utterances,
+  };
 
 }

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,8 @@ describe(`tags2dlx`, function() {
   let convert;
   let text;
 
+  const tinyText = `This_DEM is_COP a_DET sentence_N ._. Is_COP this_DEM a_DET question_N ?_?`;
+
   beforeAll(async function() {
     ({ default: convert } = await import(`../src/index.js`));
     text = await readFile(path.join(__dirname, `./test.txt`), `utf8`);
@@ -42,11 +44,44 @@ describe(`tags2dlx`, function() {
           },
         };
 
-        const output = convert(text, options);
+        const output = convert(tinyText, options);
 
-        expect(output.utterances.length).toBe(0);
+        expect(output.utterances.length).toBe(2);
 
       });
+
+    });
+
+    it(`punctuation`, function() {
+
+      const input       = `word_N -_- word_N`;
+      const punctuation = `-`;
+
+      const { utterances: [{ words }] } = convert(input, { punctuation });
+
+      expect(words.length).toBe(2);
+
+    });
+
+    it(`tag separator`, function() {
+
+      const input        = `home^N`;
+      const tagSeparator = `^`;
+
+      const { utterances: [{ words: [{ token }] }] } = convert(input, { tagSeparator });
+
+      expect(token).toBe(`home`);
+
+    });
+
+    it(`utterance separators`, function() {
+
+      const input               = `sentence_N ._. sentence_N ?_? sentence_N !_!`;
+      const utteranceSeparators = `.!?`;
+
+      const { utterances } = convert(input, { utteranceSeparators });
+
+      expect(utterances.length).toBe(3);
 
     });
 
@@ -63,13 +98,19 @@ describe(`tags2dlx`, function() {
 
     });
 
-    fit(`tokenizes utterances correctly`, function() {
+    it(`tokenizes text into utterances`, function() {
 
-      const input = `This_DEM is_COP a_DET sentence_N ._. Is_COP this_DEM a_DET question_N ?_?`;
-
-      const { utterances } = convert(input);
+      const { utterances } = convert(tinyText);
 
       expect(utterances.length).toBe(2);
+
+    });
+
+    it(`tokenizes utterances into words`, function() {
+
+      const { utterances: [{ words }] } = convert(tinyText);
+
+      expect(words.length).toBe(4); // eslint-disable-line no-magic-numbers
 
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,17 @@ describe(`tags2dlx`, function() {
 
     });
 
+    it(`tokenizes utterances correctly`, function() {
+
+      const input = `This_DEM is_COP a_DET sentence_N ._. Is_COP this_DEM a_DET question_N ?_?`;
+
+      const { utterances } = convert(input);
+
+      expect(utterances.length).toBe(2);
+      expect(utterances[0].words[3].transcription).toBe(`sentence`);
+
+    });
+
   });
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -63,14 +63,13 @@ describe(`tags2dlx`, function() {
 
     });
 
-    it(`tokenizes utterances correctly`, function() {
+    fit(`tokenizes utterances correctly`, function() {
 
       const input = `This_DEM is_COP a_DET sentence_N ._. Is_COP this_DEM a_DET question_N ?_?`;
 
       const { utterances } = convert(input);
 
       expect(utterances.length).toBe(2);
-      expect(utterances[0].words[3].transcription).toBe(`sentence`);
 
     });
 


### PR DESCRIPTION
This pull request performs tokenization of the text into utterances and words. It was necessary to tokenize words in order to tokenize utterances, so as a result this PR handles several issue at once. It was also negligible to implement several options at the same time, tackling those issues as well.

- #8 (tokenize text into utterances)
- #9 (tokenize utterances into words)
- #10 (option: tag separator)
- #12 (option: utterance separators)
- #30 (option: punctuation)