### PR TITLE
FIX: do not run conversions in parallel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitallinguistics/tags2dlx",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitallinguistics/tags2dlx",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A JavaScript (Node.js) library that converts a tagged (monolinear) text to DLx JSON format",
   "keywords": [
     "digital linguistics",

--- a/tags2dlx.js
+++ b/tags2dlx.js
@@ -48,11 +48,12 @@ async function convertFiles() {
 
   const files       = await recurse(pathArg, [ignore]);
   const progressBar = new ProgressBar(`:bar`, { total: files.length });
+  const tasks       = files.map(filepath => () => convertFile(filepath));
 
-  return Promise.all(files.map(async filepath => {
-    await convertFile(filepath);
+  for (const runTask of tasks) {
+    await runTask(); // eslint-disable-line no-await-in-loop
     progressBar.tick();
-  }));
+  }
 
 }
 


### PR DESCRIPTION
This PR adjusts the timing of how each conversion task is run. They now run in sequence rather than in parallel. While this is significantly slower, it avoids memory errors.